### PR TITLE
add new version button

### DIFF
--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -114,7 +114,10 @@ chrome.runtime.onMessage.addListener(
 (async () => {
 	let submitBtn: Element | null = null;
 	try {
-		submitBtn = (await getElementByQuerySelectorWithTimeout(`[data-cy="submit-code-btn"]`))[0];
+		submitBtn = (await getElementByQuerySelectorWithTimeout(`[data-e2e-locator="console-submit-button"]`))[0];
+		if (!submitBtn) {
+			submitBtn = (await getElementByQuerySelectorWithTimeout(`[data-cy="submit-code-btn"]`))[0];
+		}
 	} catch (e) {}
 	if (!submitBtn) return;
 	try {


### PR DESCRIPTION
This might not be working on old version since `[0]` might throw errors (maybe use `lodash` [library's](https://lodash.com/docs/4.17.15#get) `_.get()` function to safely retrieve data.